### PR TITLE
feat: 게시글 CRUD API 추가

### DIFF
--- a/src/apis/boards/boards.controller.ts
+++ b/src/apis/boards/boards.controller.ts
@@ -1,0 +1,73 @@
+import { Body, Controller, Delete, Get, Param, ParseIntPipe, Patch, Post, Query } from '@nestjs/common';
+import { BoardsService } from './boards.service';
+import { CreateBoardDTO } from './dto/create-board.dto';
+import { UpdateBoardDTO } from './dto/update-board.dto';
+import { Board } from './entity/board.entity';
+
+@Controller('boards')
+export class BoardsController {
+	constructor(
+		private readonly boardsService: BoardsService, //
+	) {}
+
+	/**
+	 * POST '/boards' 라우트 핸들러
+	 * @param createBoardDTO 게시글 생성 DTO: title, contents
+	 * @returns 생성한 게시글 정보
+	 */
+	@Post()
+	createBoard(
+		@Body() createBoardDTO: CreateBoardDTO, //
+	): Promise<Board> {
+		return this.boardsService.createBoard({ createBoardDTO });
+	}
+
+	/**
+	 * GET '/boards?page=:page' 라우트 핸들러
+	 * @param page 메인페이지의 게시글 페이지
+	 * @returns 조회한 게시글 10개
+	 */
+	@Get()
+	findAll(
+		@Query('page', ParseIntPipe) page: number, //
+	): Promise<Board[]> {
+		return this.boardsService.getTenBoards({ page });
+	}
+
+	/**
+	 * GET '/boards/:id' 라우트 핸들러
+	 * @param id 게시글 id
+	 * @returns 조회한 게시글 정보
+	 */
+	@Get('/:id')
+	findOne(
+		@Param('id', ParseIntPipe) id: number, //
+	): Promise<Board> {
+		return this.boardsService.getBoardById({ id });
+	}
+
+	/**
+	 * PATCH '/boards/:id' 라우트 핸들러
+	 * @param id 게시글 id
+	 * @param updateBoardDTO 게시글 업데이트 DTO: title, contents
+	 * @returns 업데이트한 게시글 정보
+	 */
+	@Patch('/:id')
+	updateBoard(
+		@Param('id', ParseIntPipe) id: number, //
+		@Body() updateBoardDTO: UpdateBoardDTO, //
+	): Promise<Board> {
+		return this.boardsService.updateBoard({ id, updateBoardDTO });
+	}
+
+	/**
+	 * DELETE '/boards/:id' 라우트 핸들러
+	 * @param id 게시글 id
+	 */
+	@Delete('/:id')
+	deleteBoard(
+		@Param('id', ParseIntPipe) id: number, //
+	): Promise<void> {
+		return this.boardsService.deleteBoard({ id });
+	}
+}

--- a/src/apis/boards/boards.module.ts
+++ b/src/apis/boards/boards.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { BoardsController } from './boards.controller';
+import { BoardsService } from './boards.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Board } from './entity/board.entity';
+
+@Module({
+	imports: [
+		TypeOrmModule.forFeature([
+			Board, //
+		]), //
+	],
+	controllers: [
+		BoardsController, //
+	],
+	providers: [
+		BoardsService, //
+	],
+})
+export class BoardsModule {}

--- a/src/apis/boards/boards.service.ts
+++ b/src/apis/boards/boards.service.ts
@@ -1,0 +1,91 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { Board } from './entity/board.entity';
+import { Repository } from 'typeorm';
+import { InjectRepository } from '@nestjs/typeorm';
+import {
+	IBoardsServiceCreateBoard,
+	IBoardsServiceDeleteBoard,
+	IBoardsServiceGetBoardById,
+	IBoardsServiceGetTenBoards,
+	IBoardsServiceUpdateBoard,
+} from './interfaces/boards-service.interface';
+
+@Injectable()
+export class BoardsService {
+	constructor(
+		@InjectRepository(Board)
+		private readonly boardsRepository: Repository<Board>, //
+	) {}
+
+	/**
+	 * 게시글 생성 서비스 로직
+	 * @param createBoardDTO 게시글 생성 DTO: title, contents
+	 * @returns 생성한 게시글 정보
+	 */
+	async createBoard({ createBoardDTO }: IBoardsServiceCreateBoard): Promise<Board> {
+		const board = this.boardsRepository.create({
+			title: createBoardDTO.title,
+			contents: createBoardDTO.contents,
+		});
+		await this.boardsRepository.save(board);
+
+		return board;
+	}
+
+	/**
+	 * 게시글 조회 서비스 로직
+	 * @param page 메인페이지의 게시글 페이지
+	 * @returns 조회한 게시글 10개
+	 */
+	async getTenBoards({ page }: IBoardsServiceGetTenBoards): Promise<Board[]> {
+		const queryBuilder = this.boardsRepository.createQueryBuilder('board');
+		const boards = await queryBuilder
+			.orderBy({ 'board.createdAt': 'ASC' })
+			.skip(10 * (page - 1))
+			.take(10)
+			.getMany();
+		return boards;
+	}
+
+	/**
+	 * (게시글 id 사용) 단일 게시글 조회 서비스 로직. 게시글을 찾지 못하면 NotFoundException 던짐.
+	 * @param id 게시글 id
+	 * @returns id에 해당하는 게시글
+	 */
+	async getBoardById({ id }: IBoardsServiceGetBoardById): Promise<Board> {
+		const queryBuilder = this.boardsRepository.createQueryBuilder('board');
+		const board = await queryBuilder.where('board.id = :id', { id }).getOne();
+
+		if (!board) {
+			throw new NotFoundException('게시글을 찾을 수 없습니다.');
+		}
+
+		return board;
+	}
+
+	/**
+	 * 게시글 업데이트 서비스 로직.
+	 * @param id 게시글 id
+	 * @param updateBoardDTO 게시글 업데이트 DTO: title, contents
+	 * @returns 업데이트한 게시글 정보
+	 */
+	async updateBoard({ id, updateBoardDTO }: IBoardsServiceUpdateBoard): Promise<Board> {
+		const board = await this.getBoardById({ id });
+		board.title = updateBoardDTO.title;
+		board.contents = updateBoardDTO.contents;
+		await this.boardsRepository.save(board);
+		return board;
+	}
+
+	/**
+	 * 게시글 삭제 서비스 로직. 게시글을 삭제하지 못하면 NotFoundException 던짐.
+	 * @param id 게시글 id
+	 */
+	async deleteBoard({ id }: IBoardsServiceDeleteBoard): Promise<void> {
+		const deleteResult = await this.boardsRepository.delete({ id });
+
+		if (!deleteResult.affected) {
+			throw new NotFoundException('게시글을 찾을 수 없습니다.');
+		}
+	}
+}

--- a/src/apis/boards/boards.service.ts
+++ b/src/apis/boards/boards.service.ts
@@ -27,7 +27,7 @@ export class BoardsService {
 			title: createBoardDTO.title,
 			contents: createBoardDTO.contents,
 		});
-		await this.boardsRepository.save(board);
+		await this.boardsRepository.insert(board);
 
 		return board;
 	}
@@ -73,7 +73,7 @@ export class BoardsService {
 		const board = await this.getBoardById({ id });
 		board.title = updateBoardDTO.title;
 		board.contents = updateBoardDTO.contents;
-		await this.boardsRepository.save(board);
+		await this.boardsRepository.update({ id }, board);
 		return board;
 	}
 

--- a/src/apis/boards/dto/create-board.dto.ts
+++ b/src/apis/boards/dto/create-board.dto.ts
@@ -1,0 +1,4 @@
+export class CreateBoardDTO {
+	title: string;
+	contents: string;
+}

--- a/src/apis/boards/dto/update-board.dto.ts
+++ b/src/apis/boards/dto/update-board.dto.ts
@@ -1,0 +1,4 @@
+export class UpdateBoardDTO {
+	title?: string;
+	contents?: string;
+}

--- a/src/apis/boards/entity/board.entity.ts
+++ b/src/apis/boards/entity/board.entity.ts
@@ -1,0 +1,16 @@
+import { Column, CreateDateColumn, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity()
+export class Board {
+	@PrimaryGeneratedColumn()
+	id: number;
+
+	@Column()
+	title: string;
+
+	@Column()
+	contents: string;
+
+	@CreateDateColumn()
+	createdAt: Date;
+}

--- a/src/apis/boards/interfaces/boards-service.interface.ts
+++ b/src/apis/boards/interfaces/boards-service.interface.ts
@@ -1,0 +1,23 @@
+import { CreateBoardDTO } from '../dto/create-board.dto';
+import { UpdateBoardDTO } from '../dto/update-board.dto';
+
+export interface IBoardsServiceCreateBoard {
+	createBoardDTO: CreateBoardDTO;
+}
+
+export interface IBoardsServiceGetTenBoards {
+	page: number;
+}
+
+export interface IBoardsServiceGetBoardById {
+	id: number;
+}
+
+export interface IBoardsServiceUpdateBoard {
+	id: number;
+	updateBoardDTO: UpdateBoardDTO;
+}
+
+export interface IBoardsServiceDeleteBoard {
+	id: number;
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,9 +5,11 @@ import * as redisStore from 'cache-manager-redis-store';
 import type { RedisClientOptions } from 'redis';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { BoardsModule } from './apis/boards/boards.module';
 
 @Module({
 	imports: [
+		BoardsModule,
 		ConfigModule.forRoot(),
 		TypeOrmModule.forRoot({
 			type: process.env.DATABASE_TYPE as 'mysql',

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
-  await app.listen(3000);
+	const app = await NestFactory.create(AppModule);
+	await app.listen(3100);
 }
 bootstrap();


### PR DESCRIPTION
createBoard
  - POST '/boards' 라우트 핸들러
  - 생성한 게시글 정보 반환

findAll
  - GET '/boards?page=:page' 라우트 핸들러
  - 페이지에 해당하는 조회 게시글 10개 반환

findOne
  - GET '/boards/:id' 라우트 핸들러
  - 조회한 게시글 정보 반환

updateBoard
  - PATCH '/boards/:id' 라우트 핸들러
  - 업데이트한 게시글 정보 반환

deleteBoard
  - DELETE '/boards/:id' 라우트 핸들러

feat-#9