### PR TITLE
feat: 게시글 해시태그 기능 추가

### DIFF
--- a/src/apis/boards/boards.controller.ts
+++ b/src/apis/boards/boards.controller.ts
@@ -12,7 +12,7 @@ export class BoardsController {
 
 	/**
 	 * POST '/boards' 라우트 핸들러
-	 * @param createBoardDTO 게시글 생성 DTO: title, contents
+	 * @param createBoardDTO 게시글 생성 DTO: title, contents, hashtags?
 	 * @returns 생성한 게시글 정보
 	 */
 	@Post()
@@ -49,7 +49,7 @@ export class BoardsController {
 	/**
 	 * PATCH '/boards/:id' 라우트 핸들러
 	 * @param id 게시글 id
-	 * @param updateBoardDTO 게시글 업데이트 DTO: title, contents
+	 * @param updateBoardDTO 게시글 업데이트 DTO: title?, contents?, hashtags?
 	 * @returns 업데이트한 게시글 정보
 	 */
 	@Patch('/:id')

--- a/src/apis/boards/boards.module.ts
+++ b/src/apis/boards/boards.module.ts
@@ -3,12 +3,14 @@ import { BoardsController } from './boards.controller';
 import { BoardsService } from './boards.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Board } from './entity/board.entity';
+import { HashtagsModule } from '../hashtags/hashtags.module';
 
 @Module({
 	imports: [
 		TypeOrmModule.forFeature([
 			Board, //
 		]), //
+		HashtagsModule,
 	],
 	controllers: [
 		BoardsController, //

--- a/src/apis/boards/boards.service.ts
+++ b/src/apis/boards/boards.service.ts
@@ -32,7 +32,7 @@ export class BoardsService {
 			contents,
 			hashtags: _hashtags,
 		});
-		await this.boardsRepository.insert(board);
+		await this.boardsRepository.save(board);
 		return board;
 	}
 

--- a/src/apis/boards/dto/create-board.dto.ts
+++ b/src/apis/boards/dto/create-board.dto.ts
@@ -1,4 +1,5 @@
 export class CreateBoardDTO {
 	title: string;
 	contents: string;
+	hashtags?: string[];
 }

--- a/src/apis/boards/dto/update-board.dto.ts
+++ b/src/apis/boards/dto/update-board.dto.ts
@@ -1,4 +1,3 @@
-export class UpdateBoardDTO {
-	title?: string;
-	contents?: string;
-}
+import { CreateBoardDTO } from './create-board.dto';
+
+export class UpdateBoardDTO extends CreateBoardDTO {}

--- a/src/apis/boards/entity/board.entity.ts
+++ b/src/apis/boards/entity/board.entity.ts
@@ -1,4 +1,5 @@
-import { Column, CreateDateColumn, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { Hashtag } from 'src/apis/hashtags/entity/hashtag.entity';
+import { Column, CreateDateColumn, Entity, JoinTable, ManyToMany, PrimaryGeneratedColumn } from 'typeorm';
 
 @Entity()
 export class Board {
@@ -13,4 +14,12 @@ export class Board {
 
 	@CreateDateColumn()
 	createdAt: Date;
+
+	@ManyToMany(
+		() => Hashtag, //
+		(hashtags) => hashtags.boards,
+		{ nullable: true },
+	)
+	@JoinTable()
+	hashtags: Hashtag[];
 }

--- a/src/apis/hashtags/entity/hashtag.entity.ts
+++ b/src/apis/hashtags/entity/hashtag.entity.ts
@@ -1,0 +1,17 @@
+import { Board } from 'src/apis/boards/entity/board.entity';
+import { Column, Entity, ManyToMany, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity()
+export class Hashtag {
+	@PrimaryGeneratedColumn()
+	id: number;
+
+	@Column()
+	tag: string;
+
+	@ManyToMany(
+		() => Board, //
+		(boards) => boards.hashtags,
+	)
+	boards: Board[];
+}

--- a/src/apis/hashtags/hashtags.module.ts
+++ b/src/apis/hashtags/hashtags.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Hashtag } from './entity/hashtag.entity';
+import { HashtagsService } from './hashtags.service';
+
+@Module({
+	imports: [
+		TypeOrmModule.forFeature([
+			Hashtag, //
+		]),
+	],
+	providers: [
+		HashtagsService, //
+	],
+	exports: [
+		HashtagsService, //
+	],
+})
+export class HashtagsModule {}

--- a/src/apis/hashtags/hashtags.service.ts
+++ b/src/apis/hashtags/hashtags.service.ts
@@ -1,0 +1,72 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Hashtag } from './entity/hashtag.entity';
+import { Repository } from 'typeorm';
+import {
+	IHashtagsServiceCreateHashtags,
+	IHashtagsServiceFindByTags,
+	IHashtagsServiceGetNewHashtags,
+} from './interfaces/hashtags-service.interface';
+
+@Injectable()
+export class HashtagsService {
+	constructor(
+		@InjectRepository(Hashtag)
+		private readonly hashtagsRepository: Repository<Hashtag>, //
+	) {}
+
+	/**
+	 * (해시태그 사용) 해시태그 조회 서비스 로직.
+	 * @param tags 해시태그 문자열 배열
+	 * @returns 해시태그로 조회한 해시태그 배열
+	 */
+	async findByTags({ tags }: IHashtagsServiceFindByTags): Promise<Hashtag[]> {
+		const queryBuilder = this.hashtagsRepository.createQueryBuilder('hashtag');
+		return queryBuilder.where('hashtag.tag IN (:...tags)', { tags }).getMany();
+	}
+
+	/**
+	 * 이미 존재하는 해시태그를 제외하고, 새로운 해시태그를 생성해 배열로 반환하는 서비스 로직.
+	 * @param duplicates 해시태그로 조회했을 때 이미 존재하는 해시태그 배열
+	 * @param hashtags 해시태그 문자열 배열
+	 * @returns 새롭게 생성한 해시태그 배열
+	 */
+	getNewHashtags({ duplicates, hashtags }: IHashtagsServiceGetNewHashtags): Hashtag[] {
+		const newHashtags: Hashtag[] = [];
+
+		hashtags.forEach((tag: string) => {
+			let index = -1;
+
+			if (duplicates.length > 0) {
+				index = duplicates.findIndex((duplicate: Hashtag) => duplicate.tag === tag);
+			}
+
+			if (index === -1) {
+				const newHashtag: Hashtag = this.hashtagsRepository.create({ tag });
+				newHashtags.push(newHashtag);
+			}
+		});
+		return newHashtags;
+	}
+
+	/**
+	 * 해시태그 중복 검사 후 새로운 해시태그 생성. 중복된 해시태그 배열과 새롭게 생성한 해시태그 배열을 결합해 리턴.
+	 * @param hashtags 해시태그 문자열 배열
+	 * @returns 이미 존재하는 해시태그와 새롭게 생성한 해시태그를 결합한 배열. hashtags가 null인 경우 null 리턴.
+	 */
+	async createHashtags({ hashtags }: IHashtagsServiceCreateHashtags): Promise<Hashtag[]> {
+		if (!hashtags || hashtags.length === 0) {
+			return null;
+		}
+
+		if (hashtags.length === 1 && hashtags.at(0) === '') {
+			return null;
+		}
+
+		const duplicates: Hashtag[] = await this.findByTags({ tags: hashtags });
+		const newHashtags: Hashtag[] = this.getNewHashtags({ duplicates, hashtags });
+
+		await this.hashtagsRepository.insert(newHashtags);
+		return [...duplicates, ...newHashtags];
+	}
+}

--- a/src/apis/hashtags/interfaces/hashtags-service.interface.ts
+++ b/src/apis/hashtags/interfaces/hashtags-service.interface.ts
@@ -1,0 +1,14 @@
+import { Hashtag } from '../entity/hashtag.entity';
+
+export interface IHashtagsServiceFindByTags {
+	tags: string[];
+}
+
+export interface IHashtagsServiceGetNewHashtags {
+	duplicates: Hashtag[];
+	hashtags: string[];
+}
+
+export interface IHashtagsServiceCreateHashtags {
+	hashtags?: string[];
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,10 +6,12 @@ import type { RedisClientOptions } from 'redis';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { BoardsModule } from './apis/boards/boards.module';
+import { HashtagsModule } from './apis/hashtags/hashtags.module';
 
 @Module({
 	imports: [
 		BoardsModule,
+		HashtagsModule,
 		ConfigModule.forRoot(),
 		TypeOrmModule.forRoot({
 			type: process.env.DATABASE_TYPE as 'mysql',


### PR DESCRIPTION
hashtags
  - 모듈, 서비스 추가
  - 서비스 로직
    - findByTags: 해시태그를 사용해 존재하는 해시태그를 조회하는 서비스 로직. 중복 검사 기능 수행
    - getNewHashtags: 중복 해시태그는 제외하고, 새로운 해시태그만 생성해 배열로 반환하는 서비스 로직.
    - createHashtags: findByTags, getNewHashtags 서비스 로직을 사용해 중복 검사 후 새로운 해시태그를 테이블에 저장 후, 중복 해시태그와 새롭게 생성한 해시태그를 결합해 반환하는 서비스 로직.

boards
  - 해시태그 모듈 임포트
  - 서비스 로직
    - createBoard: createHashtags 서비스 로직 사용해 해시태그 생성 후 board 엔티티에 저장
    - getBoardById: hashtags 조인 추가
    - updateBoard: createHashtags 서비스 로직 사용해 해시태그 생성 후 board 엔티티에 저장