### PR TITLE
[ feat ] 게시글, 답변 API 가드 추가, 답변 채택 API 추가

### DIFF
--- a/src/apis/answers/answers.controller.ts
+++ b/src/apis/answers/answers.controller.ts
@@ -24,7 +24,7 @@ export class AnswersController {
 		@Req() req: Request & IAuthUser, //
 		@Body() createAnswerDTO: CreateAnswerDTO, //
 	): Promise<Answer> {
-		return this.answersService.createAnswer({ createAnswerDTO });
+		return this.answersService.createAnswer({ userId: req.user.id, createAnswerDTO });
 	}
 
 	/**
@@ -41,7 +41,7 @@ export class AnswersController {
 		@Param('id', ParseIntPipe) id: number, //
 		@Body() updateAnswerDTO: UpdateAnswerDTO,
 	): Promise<Answer> {
-		return this.answersService.updateAnswer({ id, updateAnswerDTO });
+		return this.answersService.updateAnswer({ userId: req.user.id, id, updateAnswerDTO });
 	}
 
 	/**
@@ -55,6 +55,6 @@ export class AnswersController {
 		@Req() req: Request & IAuthUser, //
 		@Param('id', ParseIntPipe) id: number, //
 	): Promise<void> {
-		return this.answersService.deleteAnswer({ id });
+		return this.answersService.deleteAnswer({ userId: req.user.id, id });
 	}
 }

--- a/src/apis/answers/answers.controller.ts
+++ b/src/apis/answers/answers.controller.ts
@@ -59,6 +59,13 @@ export class AnswersController {
 		return this.answersService.deleteAnswer({ userId: req.user.id, id });
 	}
 
+	/**
+	 * PATCH '/:id/status' 라우트 핸들러
+	 * @param req HTTP 요청 객체 - req.user: id, exp, role, nickname
+	 * @param id 답변 id
+	 * @param updateAnswerStatusDTO 답변 상태 업데이트 DTO: boardId, status
+	 * @returns 업데이트한 답변 정보
+	 */
 	@Patch('/:id/status')
 	@UseGuards(restAuthGuard('access'))
 	updateAnswerStatus(

--- a/src/apis/answers/answers.controller.ts
+++ b/src/apis/answers/answers.controller.ts
@@ -16,6 +16,7 @@ import { Answer } from './entity/answer.entity';
 import { UpdateAnswerDTO } from './dto/update-answer.dto';
 import { restAuthGuard } from '../auth/guard/jwt-auth-quard';
 import { IAuthUser } from '../auth/interfaces/auth-services.interface';
+import { UpdateAnswerStatusDTO } from './dto/update-answer-status.dto';
 
 @Controller('answers')
 export class AnswersController {
@@ -71,11 +72,11 @@ export class AnswersController {
 
 	@Patch('/:id/status')
 	@UseGuards(restAuthGuard('access'))
-	updateStatus(
+	updateAnswerStatus(
 		@Req() req: Request & IAuthUser, //
 		@Param('id', ParseIntPipe) id: number, //
-		@Body('status', ParseBoolPipe) status: boolean,
-	): Promise<void> {
-		return this.answersService.updateStatus({ userId: req.user.id, id, status });
+		@Body() updateAnswerStatusDTO: UpdateAnswerStatusDTO,
+	): Promise<Answer> {
+		return this.answersService.updateAnswerStatus({ userId: req.user.id, id, updateAnswerStatusDTO });
 	}
 }

--- a/src/apis/answers/answers.controller.ts
+++ b/src/apis/answers/answers.controller.ts
@@ -1,4 +1,15 @@
-import { Body, Controller, Delete, Param, ParseIntPipe, Patch, Post, Req, UseGuards } from '@nestjs/common';
+import {
+	Body,
+	Controller,
+	Delete,
+	Param,
+	ParseBoolPipe,
+	ParseIntPipe,
+	Patch,
+	Post,
+	Req,
+	UseGuards,
+} from '@nestjs/common';
 import { AnswersService } from './answers.service';
 import { CreateAnswerDTO } from './dto/create-answer.dto';
 import { Answer } from './entity/answer.entity';
@@ -56,5 +67,15 @@ export class AnswersController {
 		@Param('id', ParseIntPipe) id: number, //
 	): Promise<void> {
 		return this.answersService.deleteAnswer({ userId: req.user.id, id });
+	}
+
+	@Patch('/:id/status')
+	@UseGuards(restAuthGuard('access'))
+	updateStatus(
+		@Req() req: Request & IAuthUser, //
+		@Param('id', ParseIntPipe) id: number, //
+		@Body('status', ParseBoolPipe) status: boolean,
+	): Promise<void> {
+		return this.answersService.updateStatus({ userId: req.user.id, id, status });
 	}
 }

--- a/src/apis/answers/answers.controller.ts
+++ b/src/apis/answers/answers.controller.ts
@@ -1,8 +1,10 @@
-import { Body, Controller, Delete, Param, ParseIntPipe, Patch, Post } from '@nestjs/common';
+import { Body, Controller, Delete, Param, ParseIntPipe, Patch, Post, Req, UseGuards } from '@nestjs/common';
 import { AnswersService } from './answers.service';
 import { CreateAnswerDTO } from './dto/create-answer.dto';
 import { Answer } from './entity/answer.entity';
 import { UpdateAnswerDTO } from './dto/update-answer.dto';
+import { restAuthGuard } from '../auth/guard/jwt-auth-quard';
+import { IAuthUser } from '../auth/interfaces/auth-services.interface';
 
 @Controller('answers')
 export class AnswersController {
@@ -12,11 +14,14 @@ export class AnswersController {
 
 	/**
 	 * POST '/answers' 라우트 핸들러
+	 * @param req HTTP 요청 객체 - req.user: id, exp, role, nickname
 	 * @param createAnswerDTO 답변 생성 DTO: contents, userId, boardId
 	 * @returns 생성한 답변 정보
 	 */
 	@Post()
+	@UseGuards(restAuthGuard('access'))
 	createAnswer(
+		@Req() req: Request & IAuthUser, //
 		@Body() createAnswerDTO: CreateAnswerDTO, //
 	): Promise<Answer> {
 		return this.answersService.createAnswer({ createAnswerDTO });
@@ -24,12 +29,15 @@ export class AnswersController {
 
 	/**
 	 * PATCH '/answers/:id' 라우트 핸들러
+	 * @param req HTTP 요청 객체 - req.user: id, exp, role, nickname
 	 * @param id 답변 id
 	 * @param updateAnswerDTO 답변 업데이트 DTO: contents
 	 * @returns 업데이트한 답변 정보
 	 */
 	@Patch('/:id')
+	@UseGuards(restAuthGuard('access'))
 	updateAnswer(
+		@Req() req: Request & IAuthUser, //
 		@Param('id', ParseIntPipe) id: number, //
 		@Body() updateAnswerDTO: UpdateAnswerDTO,
 	): Promise<Answer> {
@@ -38,10 +46,13 @@ export class AnswersController {
 
 	/**
 	 * DELETE '/answers/:id' 라우트 핸들러
+	 * @param req HTTP 요청 객체 - req.user: id, exp, role, nickname
 	 * @param id 답변 id
 	 */
 	@Delete('/:id')
+	@UseGuards(restAuthGuard('access'))
 	deleteAnswer(
+		@Req() req: Request & IAuthUser, //
 		@Param('id', ParseIntPipe) id: number, //
 	): Promise<void> {
 		return this.answersService.deleteAnswer({ id });

--- a/src/apis/answers/answers.controller.ts
+++ b/src/apis/answers/answers.controller.ts
@@ -1,15 +1,4 @@
-import {
-	Body,
-	Controller,
-	Delete,
-	Param,
-	ParseBoolPipe,
-	ParseIntPipe,
-	Patch,
-	Post,
-	Req,
-	UseGuards,
-} from '@nestjs/common';
+import { Body, Controller, Delete, Param, ParseIntPipe, Patch, Post, Req, UseGuards } from '@nestjs/common';
 import { AnswersService } from './answers.service';
 import { CreateAnswerDTO } from './dto/create-answer.dto';
 import { Answer } from './entity/answer.entity';

--- a/src/apis/answers/answers.module.ts
+++ b/src/apis/answers/answers.module.ts
@@ -4,12 +4,14 @@ import { AnswersService } from './answers.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Answer } from './entity/answer.entity';
 import { UsersModule } from '../users/users.module';
+import { BoardsModule } from '../boards/boards.module';
 
 @Module({
 	imports: [
 		TypeOrmModule.forFeature([
 			Answer, //
 		]),
+		BoardsModule,
 		UsersModule,
 	],
 	controllers: [

--- a/src/apis/answers/answers.module.ts
+++ b/src/apis/answers/answers.module.ts
@@ -3,12 +3,14 @@ import { AnswersController } from './answers.controller';
 import { AnswersService } from './answers.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Answer } from './entity/answer.entity';
+import { UsersModule } from '../users/users.module';
 
 @Module({
 	imports: [
 		TypeOrmModule.forFeature([
 			Answer, //
 		]),
+		UsersModule,
 	],
 	controllers: [
 		AnswersController, //

--- a/src/apis/answers/answers.service.ts
+++ b/src/apis/answers/answers.service.ts
@@ -78,12 +78,14 @@ export class AnswersService {
 
 	/**
 	 * 답변 업데이트 서비스 로직.
+	 * @param userId 유저 id
 	 * @param id 답변 id
 	 * @param updateAnswerDTO 답변 업데이트 DTO: contents
 	 * @returns 업데이트한 답변 정보
 	 */
 	async updateAnswer({ userId, id, updateAnswerDTO }: IAnswersServiceUpdateAnswer): Promise<Answer> {
-		const answer = await this.getAnswerById({ id });
+		await this.usersService.getOneUserById({ id: userId });
+		const answer = await this.getAnswerByIdAndUserId({ id, userId });
 		answer.contents = updateAnswerDTO.contents;
 		await this.answersRepository.save(answer);
 

--- a/src/apis/answers/answers.service.ts
+++ b/src/apis/answers/answers.service.ts
@@ -94,10 +94,18 @@ export class AnswersService {
 
 	/**
 	 * 답변 삭제 서비스 로직. 답변을 삭제하지 못하면 NotFoundException 던짐.
+	 * @param userId 유저 id
 	 * @param id 답변 id
 	 */
 	async deleteAnswer({ userId, id }: IAnswersServiceDeleteAnswer): Promise<void> {
-		const deleteResult = await this.answersRepository.delete({ id });
+		await this.usersService.getOneUserById({ id: userId });
+		await this.getAnswerByIdAndUserId({ id, userId });
+		const deleteResult = await this.answersRepository.delete({
+			id,
+			user: {
+				id: userId,
+			},
+		});
 
 		if (!deleteResult.affected) {
 			throw new NotFoundException('답변을 찾을 수 없습니다.');

--- a/src/apis/answers/answers.service.ts
+++ b/src/apis/answers/answers.service.ts
@@ -8,6 +8,7 @@ import {
 	IAnswersServiceGetAnswerById,
 	IAnswersServiceGetAnswerByIdAndUserId,
 	IAnswersServiceUpdateAnswer,
+	IAnswersServiceUpdateAnswerStatus,
 } from './interface/answers-service.interface';
 import { UsersService } from '../users/users.service';
 
@@ -112,7 +113,7 @@ export class AnswersService {
 		}
 	}
 
-	async updateAnswerStatus({ userId, id, updateAnswerStatusDTO }): Promise<Answer> {
+	async updateAnswerStatus({ userId, id, updateAnswerStatusDTO }: IAnswersServiceUpdateAnswerStatus): Promise<Answer> {
 		console.log(updateAnswerStatusDTO.boardId, typeof updateAnswerStatusDTO.boardId);
 		console.log(updateAnswerStatusDTO.status, typeof updateAnswerStatusDTO.status);
 

--- a/src/apis/answers/answers.service.ts
+++ b/src/apis/answers/answers.service.ts
@@ -112,7 +112,14 @@ export class AnswersService {
 		}
 	}
 
-	async updateStatus({ userId, id, status }): Promise<void> {
+	async updateAnswerStatus({ userId, id, updateAnswerStatusDTO }): Promise<Answer> {
+		console.log(updateAnswerStatusDTO.boardId, typeof updateAnswerStatusDTO.boardId);
+		console.log(updateAnswerStatusDTO.status, typeof updateAnswerStatusDTO.status);
+
 		const answer = await this.getAnswerById({ id });
+		answer.status = updateAnswerStatusDTO.status;
+		await this.answersRepository.save(answer);
+
+		return answer;
 	}
 }

--- a/src/apis/answers/answers.service.ts
+++ b/src/apis/answers/answers.service.ts
@@ -21,8 +21,8 @@ export class AnswersService {
 	 * @param createAnswerDTO 답변 생성 DTO - contents, userId, boardId
 	 * @returns 생성한 답변 정보
 	 */
-	async createAnswer({ createAnswerDTO }: IAnswersServiceCreateAnswer): Promise<Answer> {
-		const { contents, userId, boardId } = createAnswerDTO;
+	async createAnswer({ userId, createAnswerDTO }: IAnswersServiceCreateAnswer): Promise<Answer> {
+		const { contents, boardId } = createAnswerDTO;
 		const answer = this.answersRepository.create({
 			contents,
 			user: {
@@ -59,7 +59,7 @@ export class AnswersService {
 	 * @param updateAnswerDTO 답변 업데이트 DTO: contents
 	 * @returns 업데이트한 답변 정보
 	 */
-	async updateAnswer({ id, updateAnswerDTO }: IAnswersServiceUpdateAnswer): Promise<Answer> {
+	async updateAnswer({ userId, id, updateAnswerDTO }: IAnswersServiceUpdateAnswer): Promise<Answer> {
 		const answer = await this.getAnswerById({ id });
 		answer.contents = updateAnswerDTO.contents;
 		await this.answersRepository.save(answer);
@@ -71,7 +71,7 @@ export class AnswersService {
 	 * 답변 삭제 서비스 로직. 답변을 삭제하지 못하면 NotFoundException 던짐.
 	 * @param id 답변 id
 	 */
-	async deleteAnswer({ id }: IAnswersServiceDeleteAnswer): Promise<void> {
+	async deleteAnswer({ userId, id }: IAnswersServiceDeleteAnswer): Promise<void> {
 		const deleteResult = await this.answersRepository.delete({ id });
 
 		if (!deleteResult.affected) {

--- a/src/apis/answers/answers.service.ts
+++ b/src/apis/answers/answers.service.ts
@@ -111,4 +111,8 @@ export class AnswersService {
 			throw new NotFoundException('답변을 찾을 수 없습니다.');
 		}
 	}
+
+	async updateStatus({ userId, id, status }): Promise<void> {
+		const answer = await this.getAnswerById({ id });
+	}
 }

--- a/src/apis/answers/answers.service.ts
+++ b/src/apis/answers/answers.service.ts
@@ -6,6 +6,7 @@ import {
 	IAnswersServiceCreateAnswer,
 	IAnswersServiceDeleteAnswer,
 	IAnswersServiceGetAnswerById,
+	IAnswersServiceGetAnswerByIdAndUserId,
 	IAnswersServiceUpdateAnswer,
 } from './interface/answers-service.interface';
 import { UsersService } from '../users/users.service';
@@ -47,6 +48,26 @@ export class AnswersService {
 	async getAnswerById({ id }: IAnswersServiceGetAnswerById): Promise<Answer> {
 		const queryBuilder = this.answersRepository.createQueryBuilder('answer');
 		const answer = await queryBuilder.where('id = :id', { id }).getOne();
+
+		if (!answer) {
+			throw new NotFoundException('답변을 찾을 수 없습니다.');
+		}
+
+		return answer;
+	}
+
+	/**
+	 * (답변id와 유저 id 사용) 단일 답변 조회 서비스 로직. 답변을 찾지 못하면 NotFoundException 던짐.
+	 * @param id 답변 id
+	 * @param userId 유저 id
+	 * @returns 답변 id와 유저 id로 조회한 답변 정보
+	 */
+	async getAnswerByIdAndUserId({ id, userId }: IAnswersServiceGetAnswerByIdAndUserId): Promise<Answer> {
+		const queryBuilder = this.answersRepository.createQueryBuilder('answer');
+		const answer = await queryBuilder
+			.where('id = :id', { id })
+			.andWhere('answer.user.id = :userId', { userId })
+			.getOne();
 
 		if (!answer) {
 			throw new NotFoundException('답변을 찾을 수 없습니다.');

--- a/src/apis/answers/answers.service.ts
+++ b/src/apis/answers/answers.service.ts
@@ -11,6 +11,7 @@ import {
 	IAnswersServiceUpdateAnswerStatus,
 } from './interface/answers-service.interface';
 import { UsersService } from '../users/users.service';
+import { BoardsService } from '../boards/boards.service';
 
 @Injectable()
 export class AnswersService {
@@ -18,6 +19,7 @@ export class AnswersService {
 		@InjectRepository(Answer)
 		private readonly answersRepository: Repository<Answer>, //
 		private readonly usersService: UsersService,
+		private readonly boardsService: BoardsService,
 	) {}
 
 	/**
@@ -116,6 +118,12 @@ export class AnswersService {
 	async updateAnswerStatus({ userId, id, updateAnswerStatusDTO }: IAnswersServiceUpdateAnswerStatus): Promise<Answer> {
 		console.log(updateAnswerStatusDTO.boardId, typeof updateAnswerStatusDTO.boardId);
 		console.log(updateAnswerStatusDTO.status, typeof updateAnswerStatusDTO.status);
+		console.log(userId);
+
+		// 유저가 작성한 게시글인지 확인하기
+		// 답변 id로 답변 조회하기(유저 조인 필요)
+		// 조회한 답변 status 칼럼 true로 변경하기
+		// 답변을 작성한 유저의 포인트 10 증가시키기
 
 		const answer = await this.getAnswerById({ id });
 		answer.status = updateAnswerStatusDTO.status;

--- a/src/apis/answers/answers.service.ts
+++ b/src/apis/answers/answers.service.ts
@@ -8,17 +8,19 @@ import {
 	IAnswersServiceGetAnswerById,
 	IAnswersServiceUpdateAnswer,
 } from './interface/answers-service.interface';
+import { UsersService } from '../users/users.service';
 
 @Injectable()
 export class AnswersService {
 	constructor(
 		@InjectRepository(Answer)
 		private readonly answersRepository: Repository<Answer>, //
+		private readonly usersService: UsersService,
 	) {}
 
 	/**
 	 * 답변 생성 서비스 로직
-	 * @param createAnswerDTO 답변 생성 DTO - contents, userId, boardId
+	 * @param createAnswerDTO 답변 생성 DTO - contents, boardId
 	 * @returns 생성한 답변 정보
 	 */
 	async createAnswer({ userId, createAnswerDTO }: IAnswersServiceCreateAnswer): Promise<Answer> {

--- a/src/apis/answers/answers.service.ts
+++ b/src/apis/answers/answers.service.ts
@@ -19,17 +19,17 @@ export class AnswersService {
 	) {}
 
 	/**
-	 * 답변 생성 서비스 로직
+	 * 답변 생성 서비스 로직. 유저를 찾지 못하면 NotFoundException 던짐.
+	 * @param userId 유저 id
 	 * @param createAnswerDTO 답변 생성 DTO - contents, boardId
 	 * @returns 생성한 답변 정보
 	 */
-	async createAnswer({ userId, createAnswerDTO }: IAnswersServiceCreateAnswer): Promise<Answer> {
+	async createAnswer({ userId: id, createAnswerDTO }: IAnswersServiceCreateAnswer): Promise<Answer> {
+		const user = await this.usersService.getOneUserById({ id });
 		const { contents, boardId } = createAnswerDTO;
 		const answer = this.answersRepository.create({
 			contents,
-			user: {
-				id: userId,
-			},
+			user,
 			board: {
 				id: boardId,
 			},

--- a/src/apis/answers/dto/create-answer.dto.ts
+++ b/src/apis/answers/dto/create-answer.dto.ts
@@ -1,5 +1,4 @@
 export class CreateAnswerDTO {
 	contents: string;
-	userId: string;
 	boardId: number;
 }

--- a/src/apis/answers/dto/update-answer-status.dto.ts
+++ b/src/apis/answers/dto/update-answer-status.dto.ts
@@ -1,0 +1,4 @@
+export class UpdateAnswerStatusDTO {
+	boardId: number;
+	status: boolean;
+}

--- a/src/apis/answers/interface/answers-service.interface.ts
+++ b/src/apis/answers/interface/answers-service.interface.ts
@@ -1,4 +1,5 @@
 import { CreateAnswerDTO } from '../dto/create-answer.dto';
+import { UpdateAnswerStatusDTO } from '../dto/update-answer-status.dto';
 import { UpdateAnswerDTO } from '../dto/update-answer.dto';
 
 export interface IAnswersServiceCreateAnswer {
@@ -24,4 +25,10 @@ export interface IAnswersServiceUpdateAnswer {
 export interface IAnswersServiceDeleteAnswer {
 	userId: string;
 	id: number;
+}
+
+export interface IAnswersServiceUpdateAnswerStatus {
+	userId: string;
+	id: number;
+	updateAnswerStatusDTO: UpdateAnswerStatusDTO;
 }

--- a/src/apis/answers/interface/answers-service.interface.ts
+++ b/src/apis/answers/interface/answers-service.interface.ts
@@ -10,6 +10,11 @@ export interface IAnswersServiceGetAnswerById {
 	id: number;
 }
 
+export interface IAnswersServiceGetAnswerByIdAndUserId {
+	id: number;
+	userId: string;
+}
+
 export interface IAnswersServiceUpdateAnswer {
 	userId: string;
 	id: number;

--- a/src/apis/answers/interface/answers-service.interface.ts
+++ b/src/apis/answers/interface/answers-service.interface.ts
@@ -2,6 +2,7 @@ import { CreateAnswerDTO } from '../dto/create-answer.dto';
 import { UpdateAnswerDTO } from '../dto/update-answer.dto';
 
 export interface IAnswersServiceCreateAnswer {
+	userId: string;
 	createAnswerDTO: CreateAnswerDTO;
 }
 
@@ -10,10 +11,12 @@ export interface IAnswersServiceGetAnswerById {
 }
 
 export interface IAnswersServiceUpdateAnswer {
+	userId: string;
 	id: number;
 	updateAnswerDTO: UpdateAnswerDTO;
 }
 
 export interface IAnswersServiceDeleteAnswer {
+	userId: string;
 	id: number;
 }

--- a/src/apis/boards/boards.controller.ts
+++ b/src/apis/boards/boards.controller.ts
@@ -1,10 +1,13 @@
-import { Body, Controller, Delete, Get, Param, ParseIntPipe, Patch, Post, Query } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, ParseIntPipe, Patch, Post, Query, Req, UseGuards } from '@nestjs/common';
 import { BoardsService } from './boards.service';
 import { CreateBoardDTO } from './dto/create-board.dto';
 import { UpdateBoardDTO } from './dto/update-board.dto';
 import { Board } from './entity/board.entity';
+import { restAuthGuard } from '../auth/guard/jwt-auth-quard';
+import { IAuthUser } from '../auth/interfaces/auth-services.interface';
 
 @Controller('boards')
+@UseGuards(restAuthGuard('access'))
 export class BoardsController {
 	constructor(
 		private readonly boardsService: BoardsService, //
@@ -18,8 +21,9 @@ export class BoardsController {
 	@Post()
 	createBoard(
 		@Body() createBoardDTO: CreateBoardDTO, //
+		@Req() req: Request & IAuthUser, //
 	): Promise<Board> {
-		return this.boardsService.createBoard({ createBoardDTO });
+		return this.boardsService.createBoard({ userId: req.user.id, createBoardDTO });
 	}
 
 	/**

--- a/src/apis/boards/boards.controller.ts
+++ b/src/apis/boards/boards.controller.ts
@@ -7,7 +7,6 @@ import { restAuthGuard } from '../auth/guard/jwt-auth-quard';
 import { IAuthUser } from '../auth/interfaces/auth-services.interface';
 
 @Controller('boards')
-@UseGuards(restAuthGuard('access'))
 export class BoardsController {
 	constructor(
 		private readonly boardsService: BoardsService, //
@@ -16,9 +15,11 @@ export class BoardsController {
 	/**
 	 * POST '/boards' 라우트 핸들러
 	 * @param createBoardDTO 게시글 생성 DTO: title, contents, hashtags?
+	 * @param req HTTP 요청 객체 - req.user: id, exp, role, nickname
 	 * @returns 생성한 게시글 정보
 	 */
 	@Post()
+	@UseGuards(restAuthGuard('access'))
 	createBoard(
 		@Body() createBoardDTO: CreateBoardDTO, //
 		@Req() req: Request & IAuthUser, //
@@ -57,6 +58,7 @@ export class BoardsController {
 	 * @returns 업데이트한 게시글 정보
 	 */
 	@Patch('/:id')
+	@UseGuards(restAuthGuard('access'))
 	updateBoard(
 		@Param('id', ParseIntPipe) id: number, //
 		@Body() updateBoardDTO: UpdateBoardDTO, //
@@ -69,6 +71,7 @@ export class BoardsController {
 	 * @param id 게시글 id
 	 */
 	@Delete('/:id')
+	@UseGuards(restAuthGuard('access'))
 	deleteBoard(
 		@Param('id', ParseIntPipe) id: number, //
 	): Promise<void> {

--- a/src/apis/boards/boards.controller.ts
+++ b/src/apis/boards/boards.controller.ts
@@ -55,6 +55,7 @@ export class BoardsController {
 
 	/**
 	 * PATCH '/boards/:id' 라우트 핸들러
+	 * @param req HTTP 요청 객체 - req.user: id, exp, role, nickname
 	 * @param id 게시글 id
 	 * @param updateBoardDTO 게시글 업데이트 DTO: title, contents, hashtags?
 	 * @returns 업데이트한 게시글 정보

--- a/src/apis/boards/boards.controller.ts
+++ b/src/apis/boards/boards.controller.ts
@@ -62,10 +62,11 @@ export class BoardsController {
 	@Patch('/:id')
 	@UseGuards(restAuthGuard('access'))
 	updateBoard(
-		@Param('id', ParseIntPipe) id: number, //
-		@Body() updateBoardDTO: UpdateBoardDTO, //
+		@Req() req: Request & IAuthUser, //
+		@Param('id', ParseIntPipe) id: number,
+		@Body() updateBoardDTO: UpdateBoardDTO,
 	): Promise<Board> {
-		return this.boardsService.updateBoard({ id, updateBoardDTO });
+		return this.boardsService.updateBoard({ userId: req.user.id, id, updateBoardDTO });
 	}
 
 	/**

--- a/src/apis/boards/boards.controller.ts
+++ b/src/apis/boards/boards.controller.ts
@@ -72,13 +72,15 @@ export class BoardsController {
 
 	/**
 	 * DELETE '/boards/:id' 라우트 핸들러
+	 * @param req HTTP 요청 객체 - req.user: id, exp, role, nickname
 	 * @param id 게시글 id
 	 */
 	@Delete('/:id')
 	@UseGuards(restAuthGuard('access'))
 	deleteBoard(
-		@Param('id', ParseIntPipe) id: number, //
+		@Req() req: Request & IAuthUser, //
+		@Param('id', ParseIntPipe) id: number,
 	): Promise<void> {
-		return this.boardsService.deleteBoard({ id });
+		return this.boardsService.deleteBoard({ userId: req.user.id, id });
 	}
 }

--- a/src/apis/boards/boards.controller.ts
+++ b/src/apis/boards/boards.controller.ts
@@ -14,16 +14,18 @@ export class BoardsController {
 
 	/**
 	 * POST '/boards' 라우트 핸들러
-	 * @param createBoardDTO 게시글 생성 DTO: title, contents, hashtags?
 	 * @param req HTTP 요청 객체 - req.user: id, exp, role, nickname
+	 * @param createBoardDTO 게시글 생성 DTO: title, contents, hashtags?
 	 * @returns 생성한 게시글 정보
 	 */
 	@Post()
 	@UseGuards(restAuthGuard('access'))
 	createBoard(
-		@Body() createBoardDTO: CreateBoardDTO, //
 		@Req() req: Request & IAuthUser, //
+		@Body() createBoardDTO: CreateBoardDTO,
 	): Promise<Board> {
+		console.log(req.user);
+
 		return this.boardsService.createBoard({ userId: req.user.id, createBoardDTO });
 	}
 

--- a/src/apis/boards/boards.controller.ts
+++ b/src/apis/boards/boards.controller.ts
@@ -24,8 +24,6 @@ export class BoardsController {
 		@Req() req: Request & IAuthUser, //
 		@Body() createBoardDTO: CreateBoardDTO,
 	): Promise<Board> {
-		console.log(req.user);
-
 		return this.boardsService.createBoard({ userId: req.user.id, createBoardDTO });
 	}
 

--- a/src/apis/boards/boards.module.ts
+++ b/src/apis/boards/boards.module.ts
@@ -4,6 +4,7 @@ import { BoardsService } from './boards.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Board } from './entity/board.entity';
 import { HashtagsModule } from '../hashtags/hashtags.module';
+import { UsersModule } from '../users/users.module';
 
 @Module({
 	imports: [
@@ -11,6 +12,7 @@ import { HashtagsModule } from '../hashtags/hashtags.module';
 			Board, //
 		]), //
 		HashtagsModule,
+		UsersModule,
 	],
 	controllers: [
 		BoardsController, //

--- a/src/apis/boards/boards.module.ts
+++ b/src/apis/boards/boards.module.ts
@@ -20,5 +20,8 @@ import { UsersModule } from '../users/users.module';
 	providers: [
 		BoardsService, //
 	],
+	exports: [
+		BoardsService, //
+	],
 })
 export class BoardsModule {}

--- a/src/apis/boards/boards.service.ts
+++ b/src/apis/boards/boards.service.ts
@@ -25,14 +25,15 @@ export class BoardsService {
 	 * @returns 생성한 게시글 정보
 	 */
 	async createBoard({ userId, createBoardDTO }: IBoardsServiceCreateBoard): Promise<Board> {
-		console.log(userId);
-
 		const { title, contents, hashtags } = createBoardDTO;
 		const _hashtags = await this.hashtagsService.createHashtags({ hashtags });
 		const board = this.boardsRepository.create({
 			title,
 			contents,
 			hashtags: _hashtags,
+			user: {
+				id: userId,
+			},
 		});
 		await this.boardsRepository.save(board);
 		return board;

--- a/src/apis/boards/boards.service.ts
+++ b/src/apis/boards/boards.service.ts
@@ -29,15 +29,14 @@ export class BoardsService {
 	 * @returns 생성한 게시글 정보
 	 */
 	async createBoard({ userId: id, createBoardDTO }: IBoardsServiceCreateBoard): Promise<Board> {
-		await this.usersService.getOneUserById({ id });
-
+		const user = await this.usersService.getOneUserById({ id });
 		const { title, contents, hashtags } = createBoardDTO;
 		const _hashtags = await this.hashtagsService.createHashtags({ hashtags });
 		const board = this.boardsRepository.create({
 			title,
 			contents,
 			hashtags: _hashtags,
-			user: { id },
+			user,
 		});
 		await this.boardsRepository.save(board);
 		return board;

--- a/src/apis/boards/boards.service.ts
+++ b/src/apis/boards/boards.service.ts
@@ -82,6 +82,26 @@ export class BoardsService {
 	}
 
 	/**
+	 * (게시글 id과 유저 id 사용) 단일 게시글 조회 서비스 로직. 게시글을 찾지 못하면 NotFoundException 던짐.
+	 * @param id 게시글 id
+	 * @param userId 유저 id
+	 * @returns 게시글 id와 유저 id에 해당하는 게시글
+	 */
+	async getBoardByIdAndUserId({ id, userId }): Promise<Board> {
+		const queryBuilder = this.boardsRepository.createQueryBuilder('board');
+		const board = await queryBuilder
+			.where('board.id = :id', { id })
+			.andWhere('board.user.id = :userId', { userId })
+			.getOne();
+
+		if (!board) {
+			throw new NotFoundException('게시글을 찾을 수 없습니다.');
+		}
+
+		return board;
+	}
+
+	/**
 	 * 게시글 업데이트 서비스 로직.
 	 * @param id 게시글 id
 	 * @param updateBoardDTO 게시글 업데이트 DTO: title?, contents?, hashtags?

--- a/src/apis/boards/boards.service.ts
+++ b/src/apis/boards/boards.service.ts
@@ -68,8 +68,10 @@ export class BoardsService {
 	async getBoardById({ id }: IBoardsServiceGetBoardById): Promise<Board> {
 		const queryBuilder = this.boardsRepository.createQueryBuilder('board');
 		const board = await queryBuilder
-			.leftJoinAndSelect('board.hashtags', 'hashtag')
 			.where('board.id = :id', { id })
+			.leftJoinAndSelect('board.user', 'user')
+			.leftJoinAndSelect('board.hashtags', 'hashtag')
+			.leftJoinAndSelect('board.answers', 'answer')
 			.getOne();
 
 		if (!board) {

--- a/src/apis/boards/boards.service.ts
+++ b/src/apis/boards/boards.service.ts
@@ -21,6 +21,7 @@ export class BoardsService {
 
 	/**
 	 * 게시글 생성 서비스 로직
+	 * @param userId 게시글 생성 유저 id
 	 * @param createBoardDTO 게시글 생성 DTO: title, contents, hashtags?
 	 * @returns 생성한 게시글 정보
 	 */
@@ -47,6 +48,9 @@ export class BoardsService {
 	async getTenBoards({ page }: IBoardsServiceGetTenBoards): Promise<Board[]> {
 		const queryBuilder = this.boardsRepository.createQueryBuilder('board');
 		const boards = await queryBuilder
+			.leftJoinAndSelect('board.user', 'user')
+			.leftJoinAndSelect('board.hashtags', 'hashtags')
+			.leftJoinAndSelect('board.answers', 'answer')
 			.orderBy({ 'board.createdAt': 'DESC' })
 			.skip(10 * (page - 1))
 			.take(10)

--- a/src/apis/boards/boards.service.ts
+++ b/src/apis/boards/boards.service.ts
@@ -6,6 +6,7 @@ import {
 	IBoardsServiceCreateBoard,
 	IBoardsServiceDeleteBoard,
 	IBoardsServiceGetBoardById,
+	IBoardsServiceGetBoardByIdAndUserId,
 	IBoardsServiceGetTenBoards,
 	IBoardsServiceUpdateBoard,
 } from './interfaces/boards-service.interface';
@@ -87,7 +88,7 @@ export class BoardsService {
 	 * @param userId 유저 id
 	 * @returns 게시글 id와 유저 id에 해당하는 게시글
 	 */
-	async getBoardByIdAndUserId({ id, userId }): Promise<Board> {
+	async getBoardByIdAndUserId({ id, userId }: IBoardsServiceGetBoardByIdAndUserId): Promise<Board> {
 		const queryBuilder = this.boardsRepository.createQueryBuilder('board');
 		const board = await queryBuilder
 			.where('board.id = :id', { id })
@@ -107,8 +108,8 @@ export class BoardsService {
 	 * @param updateBoardDTO 게시글 업데이트 DTO: title?, contents?, hashtags?
 	 * @returns 업데이트한 게시글 정보
 	 */
-	async updateBoard({ id, updateBoardDTO }: IBoardsServiceUpdateBoard): Promise<Board> {
-		const board = await this.getBoardById({ id });
+	async updateBoard({ userId, id, updateBoardDTO }: IBoardsServiceUpdateBoard): Promise<Board> {
+		const board = await this.getBoardByIdAndUserId({ id, userId });
 		const { title, contents, hashtags } = updateBoardDTO;
 		board.title = title;
 		board.contents = contents;

--- a/src/apis/boards/boards.service.ts
+++ b/src/apis/boards/boards.service.ts
@@ -10,6 +10,7 @@ import {
 	IBoardsServiceUpdateBoard,
 } from './interfaces/boards-service.interface';
 import { HashtagsService } from '../hashtags/hashtags.service';
+import { UsersService } from '../users/users.service';
 
 @Injectable()
 export class BoardsService {
@@ -17,6 +18,7 @@ export class BoardsService {
 		@InjectRepository(Board)
 		private readonly boardsRepository: Repository<Board>, //
 		private readonly hashtagsService: HashtagsService, //
+		private readonly usersService: UsersService, //
 	) {}
 
 	/**
@@ -25,16 +27,16 @@ export class BoardsService {
 	 * @param createBoardDTO 게시글 생성 DTO: title, contents, hashtags?
 	 * @returns 생성한 게시글 정보
 	 */
-	async createBoard({ userId, createBoardDTO }: IBoardsServiceCreateBoard): Promise<Board> {
+	async createBoard({ userId: id, createBoardDTO }: IBoardsServiceCreateBoard): Promise<Board> {
+		await this.usersService.getOneUserById({ id });
+
 		const { title, contents, hashtags } = createBoardDTO;
 		const _hashtags = await this.hashtagsService.createHashtags({ hashtags });
 		const board = this.boardsRepository.create({
 			title,
 			contents,
 			hashtags: _hashtags,
-			user: {
-				id: userId,
-			},
+			user: { id },
 		});
 		await this.boardsRepository.save(board);
 		return board;

--- a/src/apis/boards/boards.service.ts
+++ b/src/apis/boards/boards.service.ts
@@ -122,10 +122,14 @@ export class BoardsService {
 
 	/**
 	 * 게시글 삭제 서비스 로직. 게시글을 삭제하지 못하면 NotFoundException 던짐.
+	 * @param userId 유저 id
 	 * @param id 게시글 id
 	 */
-	async deleteBoard({ id }: IBoardsServiceDeleteBoard): Promise<void> {
-		const deleteResult = await this.boardsRepository.delete({ id });
+	async deleteBoard({ userId, id }: IBoardsServiceDeleteBoard): Promise<void> {
+		const deleteResult = await this.boardsRepository.delete({
+			id,
+			user: { id: userId },
+		});
 
 		if (!deleteResult.affected) {
 			throw new NotFoundException('게시글을 찾을 수 없습니다.');

--- a/src/apis/boards/boards.service.ts
+++ b/src/apis/boards/boards.service.ts
@@ -104,8 +104,9 @@ export class BoardsService {
 
 	/**
 	 * 게시글 업데이트 서비스 로직.
+	 * @param userId 유저 id
 	 * @param id 게시글 id
-	 * @param updateBoardDTO 게시글 업데이트 DTO: title?, contents?, hashtags?
+	 * @param updateBoardDTO 게시글 업데이트 DTO: title, contents, hashtags?
 	 * @returns 업데이트한 게시글 정보
 	 */
 	async updateBoard({ userId, id, updateBoardDTO }: IBoardsServiceUpdateBoard): Promise<Board> {

--- a/src/apis/boards/boards.service.ts
+++ b/src/apis/boards/boards.service.ts
@@ -109,6 +109,8 @@ export class BoardsService {
 	 * @returns 업데이트한 게시글 정보
 	 */
 	async updateBoard({ userId, id, updateBoardDTO }: IBoardsServiceUpdateBoard): Promise<Board> {
+		await this.usersService.getOneUserById({ id: userId });
+
 		const board = await this.getBoardByIdAndUserId({ id, userId });
 		const { title, contents, hashtags } = updateBoardDTO;
 		board.title = title;
@@ -125,6 +127,9 @@ export class BoardsService {
 	 * @param id 게시글 id
 	 */
 	async deleteBoard({ userId, id }: IBoardsServiceDeleteBoard): Promise<void> {
+		await this.usersService.getOneUserById({ id: userId });
+		await this.getBoardByIdAndUserId({ id, userId });
+
 		const deleteResult = await this.boardsRepository.delete({
 			id,
 			user: { id: userId },

--- a/src/apis/boards/boards.service.ts
+++ b/src/apis/boards/boards.service.ts
@@ -24,7 +24,9 @@ export class BoardsService {
 	 * @param createBoardDTO 게시글 생성 DTO: title, contents, hashtags?
 	 * @returns 생성한 게시글 정보
 	 */
-	async createBoard({ createBoardDTO }: IBoardsServiceCreateBoard): Promise<Board> {
+	async createBoard({ userId, createBoardDTO }: IBoardsServiceCreateBoard): Promise<Board> {
+		console.log(userId);
+
 		const { title, contents, hashtags } = createBoardDTO;
 		const _hashtags = await this.hashtagsService.createHashtags({ hashtags });
 		const board = this.boardsRepository.create({

--- a/src/apis/boards/entity/board.entity.ts
+++ b/src/apis/boards/entity/board.entity.ts
@@ -1,6 +1,5 @@
 import { User } from 'src/apis/users/entity/user.entity';
 import { Hashtag } from 'src/apis/hashtags/entity/hashtag.entity';
-
 import {
 	Column,
 	CreateDateColumn,

--- a/src/apis/boards/entity/board.entity.ts
+++ b/src/apis/boards/entity/board.entity.ts
@@ -13,7 +13,6 @@ import {
 } from 'typeorm';
 import { Answer } from 'src/apis/answers/entity/answer.entity';
 
-
 @Entity()
 export class Board {
 	@PrimaryGeneratedColumn()
@@ -36,12 +35,10 @@ export class Board {
 	})
 	createdAt: Date;
 
-
 	@ManyToOne(
 		() => User, //
 		(user) => user.boards,
 	)
-
 	user: User;
 
 	@ManyToMany(
@@ -60,5 +57,4 @@ export class Board {
 		{ nullable: true },
 	)
 	answers: Answer[];
-
 }

--- a/src/apis/boards/interfaces/boards-service.interface.ts
+++ b/src/apis/boards/interfaces/boards-service.interface.ts
@@ -2,6 +2,7 @@ import { CreateBoardDTO } from '../dto/create-board.dto';
 import { UpdateBoardDTO } from '../dto/update-board.dto';
 
 export interface IBoardsServiceCreateBoard {
+	userId: string;
 	createBoardDTO: CreateBoardDTO;
 }
 

--- a/src/apis/boards/interfaces/boards-service.interface.ts
+++ b/src/apis/boards/interfaces/boards-service.interface.ts
@@ -26,5 +26,6 @@ export interface IBoardsServiceUpdateBoard {
 }
 
 export interface IBoardsServiceDeleteBoard {
+	userId: string;
 	id: number;
 }

--- a/src/apis/boards/interfaces/boards-service.interface.ts
+++ b/src/apis/boards/interfaces/boards-service.interface.ts
@@ -14,7 +14,13 @@ export interface IBoardsServiceGetBoardById {
 	id: number;
 }
 
+export interface IBoardsServiceGetBoardByIdAndUserId {
+	id: number;
+	userId: string;
+}
+
 export interface IBoardsServiceUpdateBoard {
+	userId: string;
 	id: number;
 	updateBoardDTO: UpdateBoardDTO;
 }

--- a/src/apis/users/interface/users-service.interface.ts
+++ b/src/apis/users/interface/users-service.interface.ts
@@ -27,3 +27,8 @@ export interface IUserServiceCreateUser {
 export interface IUserServiceGetOneUserById {
 	id: string;
 }
+
+export interface IUsersServiceUpdateUserPoint {
+	id: string;
+	status: boolean;
+}

--- a/src/apis/users/interface/users-service.interface.ts
+++ b/src/apis/users/interface/users-service.interface.ts
@@ -23,3 +23,7 @@ export interface IUserServiceCheckToken {
 export interface IUserServiceCreateUser {
 	createUserDTO: CreateUserDTO;
 }
+
+export interface IUserServiceGetOneUserById {
+	id: string;
+}

--- a/src/apis/users/users.service.ts
+++ b/src/apis/users/users.service.ts
@@ -13,6 +13,7 @@ import {
 	IUserServiceIsValidEmail,
 	IUserServiceIsValidNickname,
 	IUserServiceSendToken,
+	IUsersServiceUpdateUserPoint,
 } from './interface/users-service.interface';
 
 @Injectable()
@@ -137,5 +138,24 @@ export class UsersService {
 		}
 
 		return user;
+	}
+
+	/**
+	 * 유저 포인트 업데이트 서비스 로직.
+	 * status가 true인 경우(유저가 작성한 답변이 채택된 경우) point 10 증가
+	 * status가 false인 경우(채택된 답변이 채택 취소된 경우) point 10 감소
+	 * @param id 유저 id
+	 * @param status 답변 채택 여부
+	 */
+	async updateUserPoint({ id, status }: IUsersServiceUpdateUserPoint): Promise<void> {
+		const user = await this.getOneUserById({ id });
+
+		if (status) {
+			user.point += 10;
+		} else {
+			user.point -= 10;
+		}
+
+		await this.userRepository.save(user);
 	}
 }

--- a/src/apis/users/users.service.ts
+++ b/src/apis/users/users.service.ts
@@ -1,5 +1,5 @@
 import { MailerService } from '@nestjs-modules/mailer';
-import { CACHE_MANAGER, Inject, Injectable, UnprocessableEntityException } from '@nestjs/common';
+import { CACHE_MANAGER, Inject, Injectable, NotFoundException, UnprocessableEntityException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Cache } from 'cache-manager';
 import { DataSource, Repository } from 'typeorm';
@@ -9,6 +9,7 @@ import {
 	IUserServiceCheckToken,
 	IUserServiceCreateUser,
 	IUserServiceFindOneByEmail,
+	IUserServiceGetOneUserById,
 	IUserServiceIsValidEmail,
 	IUserServiceIsValidNickname,
 	IUserServiceSendToken,
@@ -120,5 +121,21 @@ export class UsersService {
 
 		// const user = await this.userRepository.save({ ...createUserDTO });
 		// return user ? '회원가입 성공' : '회원가입 실패';
+	}
+
+	/**
+	 * 유저 조회 서비스 로직. 유저를 찾지 못하면 NotFoundException 던짐
+	 * @param id 유저 id
+	 * @returns id로 조회한 유저 정보
+	 */
+	async getOneUserById({ id }: IUserServiceGetOneUserById): Promise<User> {
+		const queryBuilder = this.userRepository.createQueryBuilder('user');
+		const user = await queryBuilder.where('user.id = :id', { id }).getOne();
+
+		if (!user) {
+			throw new NotFoundException('유저를 찾을 수 없습니다.');
+		}
+
+		return user;
 	}
 }


### PR DESCRIPTION
가드가 필요한 게시글, 답변 라우트 핸들러에 가드 추가하였음

답변 채택 API 추가 (PATCH 'answers/:id/status')
답변 채택 서비스 로직
- updateAnswerStatus
  - Boards 서비스의 getBoardByIdAndUserId를 사용하여 유저가 작성한 게시글인지 확인
  - 답변 id를 사용해 답변 정보와 답변을 작성한 유저 정보 조회
  - 답변 상태 업데이트
    - true: 답변 채택됨
    - false: 답변 채택되지 않음(기본값)
  - Users 서비스의 updateUserPoint를 사용하여 유저의 포인트 업데이트
  - 업데이트한 답변 저장
  - 업데이트한 답변 반환