### PR TITLE
Feat: Deployment  docker prod 환경 만듦

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,0 +1,11 @@
+FROM node:18
+
+COPY ./package.json /romance-service/
+COPY ./yarn.lock /romance-service/
+WORKDIR /romance-service/
+RUN yarn install --production
+
+COPY . /romance-service/
+
+RUN yarn build
+CMD yarn start:prod

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -1,0 +1,22 @@
+version: '3.7'
+
+services:
+  romance-service:
+    build:
+      context: .
+      dockerfile: DockerFile
+    volumes:
+      - ./src:/romance-service/src
+    restart: always
+    ports:
+      - 3100:3100
+    env_file:
+      - ./.env.prod
+  ## mysql은 AWS RDS로 외부로 빼두었다.
+  romance-redis:
+    image: redis:latest
+    volumes: #redis 마운트할 볼륨 설정
+      - ./redis/redis.conf:/redis/redis.conf
+    restart: always
+    ports:
+      - 6379:6379

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,6 +7,7 @@ services:
       dockerfile: DockerFile
     volumes:
       - ./src:/romance-service/src
+    restart: always
     ports:
       - 3100:3100
     env_file:
@@ -19,6 +20,7 @@ services:
       MYSQL_ROOT_PASSWORD: 'root'
       MYSQL_USER: 'root'
       MYSQL_PASSWORD: 'root'
+    restart: always
     ports:
       - 3306:3306
 


### PR DESCRIPTION
Dockerfile.prod
배포환경에 맞게 추가
```
RUN yarn install --production
RUN yarn build
```
docker-compose.pord.yaml
AWS RDS로 mysql을 외부로 빼주었기에 mysql 컨테이너를 없앴다.
.env.prod는 올리지 않았지만 이에 맞게 수정했다.