### PR TITLE
[ fix ] 답변 조회 시 답변 좋아요 개수 조회 추가

### DIFF
--- a/src/apis/answers/answers.service.ts
+++ b/src/apis/answers/answers.service.ts
@@ -168,6 +168,7 @@ export class AnswersService {
 			.where('answer.board.id = :boardId', { boardId })
 			.andWhere('answer.status = :status', { status })
 			.leftJoinAndSelect('answer.user', 'user')
+			.leftJoinAndSelect('answer.likedByUsers', 'likedByUsers')
 			.getMany();
 
 		return answers;


### PR DESCRIPTION
fix: getAnswersByBoardId 서비스 로직 수정 

likedByUsers 칼럼과 조인하여 좋아요를 누른 유저를 조회할 수 있게 하였음

fix-#41