### PR TITLE
Fix: deployment auth/login API 요청시 Cookie에대한 설정 추가, SameSite=none추가

### DIFF
--- a/src/apis/auth/auth.service.ts
+++ b/src/apis/auth/auth.service.ts
@@ -56,6 +56,7 @@ export class AuthService {
 		res.cookie('refreshToken', refreshToken, {
 			domain: process.env.FRONTEND_DOMAIN, //
 			path: '/',
+			sameSite: 'none',
 			httpOnly: true,
 			secure: false, //프론트의 주소가 https로 배포되면 true로 바꿀것.
 		});


### PR DESCRIPTION
배포환경에서 두개의 쿠키가 발생하여 응답헤더와는 다른 쿠키가 같이 담겨오는 문제가 생겨 samesite옵션을 추가했습니다.