### PR TITLE
fix: searchBoards 서비스 로직 수정

### DIFF
--- a/src/apis/boards/boards.service.ts
+++ b/src/apis/boards/boards.service.ts
@@ -64,7 +64,8 @@ export class BoardsService {
 			.orderBy({ 'board.createdAt': 'DESC' })
 			.skip(10 * (page - 1))
 			.take(10)
-			.where('title LIKE :keyword', { keyword: `%${keyword}%` })
+			.where('user.nickname LIKE :nickname', { nickname: `%${keyword}%` })
+			.orWhere('title LIKE :keyword', { keyword: `%${keyword}%` })
 			.getMany();
 
 		return boards;


### PR DESCRIPTION
where와 orWhere에서 유저 닉네임, 게시글 제목에 대해 LIKE 검색을 수행하도록 수정하였음

fix-#55